### PR TITLE
fix: close options on mode change

### DIFF
--- a/app/src/main/kotlin/org/fossify/camera/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/camera/activities/MainActivity.kt
@@ -531,6 +531,7 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener, Camera
             layoutTop.toggleTimer.beVisible()
             layoutTop.toggleTimer.fadeIn()
         }
+        closeOptions()
         setupPreviewImage(true)
         selectPhotoTab()
     }
@@ -541,6 +542,7 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener, Camera
             layoutTop.toggleTimer.fadeOut()
             layoutTop.toggleTimer.beGone()
         }
+        closeOptions()
         setupPreviewImage(false)
         selectVideoTab()
     }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Fixed not closing options when changed the photo/video mode
- Before that, it leaked non-existent options from photo mode in video mode and vice versa


#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Camera/blob/master/CONTRIBUTING.md).
