### PR TITLE
location -> geolocation

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,7 +49,7 @@
     <string name="keep_settings_visible">Keep the setting buttons visible</string>
     <string name="always_open_back_camera">Always open the app with the Back camera</string>
     <string name="save_photo_metadata">Save photo exif metadata</string>
-    <string name="save_photo_video_location">Save photo and video location</string>
+    <string name="save_photo_video_location">Save photo and video geolocation</string>
     <string name="photo_compression_quality">Photo compression quality</string>
     <string name="shutter">Shutter</string>
     <!--


### PR DESCRIPTION
location -> geolocation
change the text to make it clearer that this setting has to do with device/camera location not output file location.

<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- changed documentation - changed the text in the label from "Save photo and video location" to "Save photo and video geolocation"

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
<img alt="before" src="https://github.com/user-attachments/assets/2cdfff2f-de4a-4289-8bf1-8bf9a45d75c6" width=180 />
- After (doctored image since I didn't build my changes):
<img alt="after" src="https://github.com/user-attachments/assets/8d1768b0-8ee4-4f0b-9288-8bc29cf17a41" width=180 />

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Camera/blob/master/CONTRIBUTING.md).
