### PR TITLE
Closes #20. Support high resolution output sizes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support high resolution output modes if the config preference is set to maximize quality. ([#20])
 
 ## [1.1.0] - 2025-07-21
 ### Changed
@@ -39,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[#20]: https://github.com/FossifyOrg/Camera/issues/20
 [#97]: https://github.com/FossifyOrg/Camera/issues/97
 
 [Unreleased]: https://github.com/FossifyOrg/Camera/compare/1.1.0...HEAD

--- a/app/src/main/kotlin/org/fossify/camera/helpers/ImageQualityManager.kt
+++ b/app/src/main/kotlin/org/fossify/camera/helpers/ImageQualityManager.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.core.CameraSelector
 import org.fossify.camera.extensions.config
 import org.fossify.camera.models.CameraSelectorImageQualities
+import org.fossify.camera.models.CaptureMode
 import org.fossify.camera.models.MySize
 import org.fossify.commons.extensions.showErrorToast
 
@@ -32,8 +33,14 @@ class ImageQualityManager(private val activity: AppCompatActivity) {
                         val configMap =
                             characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
                                 ?: continue
-                        val imageSizes = configMap.getOutputSizes(ImageFormat.JPEG)
+                        val standardImageSizes = configMap.getOutputSizes(ImageFormat.JPEG)
                             .map { MySize(it.width, it.height) }
+                        val imageSizes = if (activity.config.captureMode == CaptureMode.MAXIMIZE_QUALITY) {
+                            standardImageSizes + configMap.getHighResolutionOutputSizes(ImageFormat.JPEG)
+                                .map { MySize(it.width, it.height) }
+                        } else {
+                            standardImageSizes
+                        }
                         val cameraSelector = lensFacing.toCameraSelector()
                         imageQualities.add(CameraSelectorImageQualities(cameraSelector, imageSizes))
                     }


### PR DESCRIPTION
If the config preference is set to maximize quality, then also consider high resolution outputs.
Switch to using a ResolutionSelector instead of the deprecated setTargetResolution API, as some of the higher resolution modes are only supported that way.

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->

Fixes #20. After testing a variant of the diff in that ticket I noticed that it only fixes high resolution on one device I have access to, and another did not. The fix for that one was to switch to the newer API.

#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #20 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
