### PR TITLE
fix: override abstract methods in location listener

### DIFF
--- a/app/src/main/kotlin/org/fossify/camera/helpers/SimpleLocationManager.kt
+++ b/app/src/main/kotlin/org/fossify/camera/helpers/SimpleLocationManager.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
+import android.os.Bundle
 import androidx.annotation.RequiresPermission
 import org.fossify.camera.extensions.checkLocationPermission
 import org.fossify.commons.activities.BaseSimpleActivity
@@ -15,12 +16,21 @@ class SimpleLocationManager(private val activity: BaseSimpleActivity) {
         private const val LOCATION_UPDATE_MIN_DISTANCE_M = 10F
     }
 
-    private val locationManager = activity.getSystemService(LocationManager::class.java)!!
-    private val locationListener = LocationListener { location ->
-        this@SimpleLocationManager.location = location
-    }
-
     private var location: Location? = null
+
+    private val locationManager = activity.getSystemService(LocationManager::class.java)!!
+    private val locationListener = object: LocationListener {
+        override fun onLocationChanged(location: Location) {
+            this@SimpleLocationManager.location = location
+        }
+
+        // No-op methods that must be overridden.
+        // See https://github.com/FossifyOrg/Camera/issues/177
+        @Suppress("DEPRECATION")
+        override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) {}
+        override fun onProviderEnabled(provider: String) {}
+        override fun onProviderDisabled(provider: String) {}
+    }
 
     fun getLocation(): Location? {
         if (location == null) {


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Some `LocationListener` methods don't have default implementations on Android 10 and older versions, and that leads to the crash.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Ran app with **Save photo and video location** enabled and location service off on Android 10
 - Saving location metadata on Android 13

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Camera/issues/177

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
