### PR TITLE
feat: change default save location to DCIM/Camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changed default photo save location to "DCIM/Camera" ([#18])
 
 ## [1.3.1] - 2025-10-05
 ### Changed
@@ -58,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[#18]: https://github.com/FossifyOrg/Camera/issues/18
 [#20]: https://github.com/FossifyOrg/Camera/issues/20
 [#97]: https://github.com/FossifyOrg/Camera/issues/97
 [#157]: https://github.com/FossifyOrg/Camera/issues/157

--- a/app/src/main/kotlin/org/fossify/camera/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/camera/helpers/Config.kt
@@ -17,11 +17,10 @@ class Config(context: Context) : BaseConfig(context) {
         get(): String {
             var path = prefs.getString(
                 SAVE_PHOTOS,
-                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM).toString()
+                "${Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM)}/Camera"
             )
             if (!File(path).exists() || !File(path).isDirectory) {
-                path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM)
-                    .toString()
+                path = "${Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM)}/Camera"
                 savePhotosFolder = path
             }
             return path!!


### PR DESCRIPTION

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Changed the default save location to `DCIM/Camera`. This aligns with other camera apps.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - 

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Camera/issues/18

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ ] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
