### PR TITLE
fix: handle device rotations from before app start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed wrongly oriented photos and videos when opening in landscape ([#294])
+
 ## [1.5.0] - 2026-01-30
 ### Added
 - Added support for custom fonts

--- a/app/src/main/kotlin/org/fossify/camera/implementations/CameraXPreview.kt
+++ b/app/src/main/kotlin/org/fossify/camera/implementations/CameraXPreview.kt
@@ -105,7 +105,7 @@ class CameraXPreview(
 ) : MyPreview, DefaultLifecycleObserver {
 
     companion object {
-        // Auto focus is 1/6 of the area.
+        // Autofocus is 1/6 of the area.
         private const val AF_SIZE = 1.0f / 6.0f
         private const val AE_SIZE = AF_SIZE * 1.5f
         private const val CAMERA_MODE_SWITCH_WAIT_TIME = 500L
@@ -136,11 +136,9 @@ class CameraXPreview(
                     else -> Surface.ROTATION_0
                 }
 
-                if (lastRotation != rotation) {
-                    preview?.targetRotation = rotation
-                    imageCapture?.targetRotation = rotation
-                    videoCapture?.targetRotation = rotation
-                    lastRotation = rotation
+                if (targetRotation != rotation) {
+                    targetRotation = rotation
+                    applyCaptureRotation(rotation)
                 }
             }
         }
@@ -178,7 +176,7 @@ class CameraXPreview(
     private var cameraSelector = config.lastUsedCameraLens.toCameraSelector()
     private var flashMode = FLASH_MODE_OFF
     private var isPhotoCapture = initInPhotoMode
-    private var lastRotation = 0
+    private var targetRotation: Int? = null
     private var lastCameraStartTime = 0L
     private var simpleLocationManager: SimpleLocationManager? = null
 
@@ -200,7 +198,7 @@ class CameraXPreview(
                 videoQualityManager.initSupportedQualities(provider)
                 bindCameraUseCases()
                 setupCameraObservers()
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 val errorMessage =
                     if (switching) R.string.camera_switch_error else R.string.camera_open_error
                 activity.toast(errorMessage)
@@ -260,8 +258,14 @@ class CameraXPreview(
             )
         }
         preview = previewUseCase
+        applyCaptureRotation(targetRotation ?: rotation)
         setupZoomAndFocus()
         setFlashlightState(config.flashlightState)
+    }
+
+    private fun applyCaptureRotation(rotation: Int) {
+        imageCapture?.targetRotation = rotation
+        videoCapture?.targetRotation = rotation
     }
 
     private fun buildPreview(resolution: Size, rotation: Int): Preview {
@@ -269,7 +273,7 @@ class CameraXPreview(
             .setTargetRotation(rotation)
             .setResolutionSelector(getResolutionSelector(resolution))
             .build().apply {
-                setSurfaceProvider(previewView.surfaceProvider)
+                surfaceProvider = previewView.surfaceProvider
             }
     }
 
@@ -307,7 +311,7 @@ class CameraXPreview(
     private fun getResolutionSelector(resolution: Size): ResolutionSelector {
         return ResolutionSelector.Builder()
             .setResolutionStrategy(ResolutionStrategy(resolution, FALLBACK_RULE_CLOSEST_LOWER_THEN_HIGHER))
-            .setResolutionFilter { supportedSizes, rotationDegrees ->
+            .setResolutionFilter { supportedSizes, _ ->
                 // Sort by closest image ratio
                 supportedSizes.sortedBy {
                     size -> abs(size.width / size.height.toFloat() - resolution.width / resolution.height.toFloat())
@@ -316,6 +320,7 @@ class CameraXPreview(
             .setAllowedResolutionMode(getAllowedResolutionMode())
             .build()
     }
+
 
     private fun getAllowedResolutionMode(): Int {
         return when (config.captureMode) {


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
Previously, both images and videos where stored with the wrong orientation if you had rotated the phone to landscape before opening the app. Only rotations while the camera app is open were handled by the listener.

The target rotation also needs to be applied immediately at bind time, to correctly react to rotations that happened before the app lifecycle.

The commit also addresses linter warnings in the same file. I figured they are too small to justify a separate PR, but let me know if they shall be removed again.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested on emulator and Pixel 10 physical device

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Closes #294

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
