### PR TITLE
Rotate countdown timer text with device orientation

### DIFF
--- a/app/src/main/kotlin/org/fossify/camera/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/camera/activities/MainActivity.kt
@@ -671,6 +671,7 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener, Camera
             shutter,
             layoutTop.settings,
             lastPhotoVideoPreview,
+            timerText,
             layoutTimer.timerOff,
             layoutTimer.timer3s,
             layoutTimer.timer5s,


### PR DESCRIPTION
## Summary
- Include `timerText` in `animateViews()` so the live countdown digits rotate with the other camera controls.

Fixes #91

## Test plan
- [x] `./gradlew :app:compileFossDebugKotlin`
- [x] `./gradlew :app:detekt`
- [ ] Start a 10s photo timer, rotate to landscape, confirm countdown digits rotate
